### PR TITLE
Add nudgeOversize option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,8 @@ Default: 4 pixels
 ### angle ###
 Specifies the label rotation angle in degrees clockwise. Note this option will not work if your version of Flot does not support the angle option. You may modify jquery.flot.js as described [here](https://github.com/cleroux/flot.barlabels/issues/4) or [download the modified version from this repository's example directory](https://raw.githubusercontent.com/cleroux/flot.barlabels/master/examples/flot/jquery.flot.js) to enable this behavior.  
 Default: 0 deg
+### nudgeOversize ###
+Specifies whether or not to nudge oversize value labels to the `outside` position.
+Value: true or false
+Default: true
+

--- a/jquery.flot.barlabels.js
+++ b/jquery.flot.barlabels.js
@@ -19,7 +19,8 @@
                 labelFormatter: function(v) {return v;},
                 position: "middle",
                 padding: 4,
-                angle: 0
+                angle: 0,
+                nudgeOversize: true
             }
         }
     };
@@ -87,7 +88,7 @@
                             text = lf ? lf(x-b, series) : x-b;
                         }
                         let textInfo = barLabels.getTextInfo(layer, text, series.labels.font, series.labels.angle, width);
-                        if (Math.abs((series.xaxis.p2c(0) - width)) - series.labels.padding < textInfo.width) {
+                        if (series.labels.nudgeOversize && Math.abs((series.xaxis.p2c(0) - width)) - series.labels.padding < textInfo.width) {
                             pos = positions.outside;
                         }
 
@@ -141,7 +142,7 @@
                             text = lf ? lf(y - b, series) : y - b;
                         }
                         let textInfo = barLabels.getTextInfo(layer, text, series.labels.font, series.labels.angle, width);
-                        if (Math.abs((series.yaxis.p2c(0) - series.yaxis.p2c(y))) - series.labels.padding < textInfo.height) {
+                        if (series.labels.nudgeOversize && Math.abs((series.yaxis.p2c(0) - series.yaxis.p2c(y))) - series.labels.padding < textInfo.height) {
                             pos = positions.outside;
                         }
 


### PR DESCRIPTION
Labels that are too large to fit inside the bar are nudged to the `outside` position.  This PR adds an option to disable this behavior.

```
labels: {
	position: "middle",
	nudgeOversize: false
},
```

`nudgeOversize: true` (default):
![image](https://github.com/cleroux/flot.barlabels/assets/1497949/d642d7c1-a1ae-4324-aa1a-0bfa84cb34dc)


`nudgeOversize: false`:
![image](https://github.com/cleroux/flot.barlabels/assets/1497949/3b8bc58e-0935-4214-8b2d-e39dd58278f7)
